### PR TITLE
feat: 数据库初始化脚本优化：精简sys_upload表的引擎定义

### DIFF
--- a/server/db/init.sql
+++ b/server/db/init.sql
@@ -738,4 +738,4 @@ CREATE TABLE `sys_upload` (
   `url` varchar(255) NOT NULL COMMENT '文件地址',
   `ext` varchar(255) DEFAULT NULL COMMENT '拓展名',
   PRIMARY KEY (`upload_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='文件上传记录';
+) ENGINE=InnoDB COMMENT='文件上传记录';


### PR DESCRIPTION
成功地对sys_upload表的创建语句进行了小幅调整。移除了默认的CHARACTER SET和COLLATE设置，因为这些设置是InnoDB引擎的默认值，从而简化了数据库初始化脚本。 这也避免初始化时候因为字符集不同而造成奇怪的问题。