### PR TITLE
fix(server): 修复根目录添加菜单，顶部标签不展示的问题

### DIFF
--- a/server/src/module/system/menu/utils.ts
+++ b/server/src/module/system/menu/utils.ts
@@ -59,7 +59,7 @@ const formatTreeNodeBuildMenus = (menus: any[]): any[] => {
       const childrenRouter: any = {};
       childrenRouter.path = menu.path;
       childrenRouter.component = menu.component;
-      childrenRouter.name = Lodash.capitalize(menu.name);
+      childrenRouter.name = Lodash.capitalize(menu.path);
       childrenRouter.meta = setMeta(menu);
       childrenRouter.query = menu.query;
       childrenList.push(childrenRouter);


### PR DESCRIPTION

修复根目录添加菜单后，顶部标签没有标签的问题
![image](https://github.com/user-attachments/assets/68c62031-d38b-4189-b879-7fc652f17e34)
