### PR TITLE
fix(server): 修复字典，参数，通知模块新增数据时没有附带创建人和创建时间的问题

### DIFF
--- a/server/src/module/system/config/config.controller.ts
+++ b/server/src/module/system/config/config.controller.ts
@@ -1,9 +1,10 @@
-import { Controller, Get, Post, Body, Put, Param, Delete, Query, Res } from '@nestjs/common';
+import { Controller, Get, Post, Body, Put, Param, Delete, Request, Query, Res } from '@nestjs/common';
 import { Response } from 'express';
 import { ApiTags, ApiOperation, ApiBody } from '@nestjs/swagger';
 import { ConfigService } from './config.service';
 import { CreateConfigDto, UpdateConfigDto, ListConfigDto } from './dto/index';
 import { RequirePermission } from 'src/common/decorators/require-premission.decorator';
+import { GetNowDate } from 'src/common/utils';
 
 @ApiTags('参数设置')
 @Controller('system/config')
@@ -18,7 +19,9 @@ export class ConfigController {
   })
   @RequirePermission('system:config:add')
   @Post()
-  create(@Body() createConfigDto: CreateConfigDto) {
+  create(@Body() createConfigDto: CreateConfigDto, @Request() req) {
+    createConfigDto['createTime'] = GetNowDate();
+    createConfigDto['createBy'] = req.user.user.userName;
     return this.configService.create(createConfigDto);
   }
 

--- a/server/src/module/system/dict/dict.controller.ts
+++ b/server/src/module/system/dict/dict.controller.ts
@@ -1,9 +1,10 @@
-import { Controller, Get, Post, Body, Query, Put, Res, HttpCode, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Query, Request, Put, Res, HttpCode, Param, Delete } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBody, ApiConsumes, ApiQuery, ApiBearerAuth } from '@nestjs/swagger';
 import { DictService } from './dict.service';
 import { CreateDictTypeDto, UpdateDictTypeDto, ListDictType, CreateDictDataDto, UpdateDictDataDto, ListDictData } from './dto/index';
 import { RequirePermission } from 'src/common/decorators/require-premission.decorator';
 import { Response } from 'express';
+import { GetNowDate } from 'src/common/utils';
 
 @ApiTags('字典管理')
 @Controller('system/dict')
@@ -21,7 +22,9 @@ export class DictController {
   @RequirePermission('system:dict:add')
   @HttpCode(200)
   @Post('/type')
-  createType(@Body() createDictTypeDto: CreateDictTypeDto) {
+  createType(@Body() createDictTypeDto: CreateDictTypeDto, @Request() req) {
+    createDictTypeDto['createTime'] = GetNowDate();
+    createDictTypeDto['createBy'] = req.user.user.userName;
     return this.dictService.createType(createDictTypeDto);
   }
 
@@ -87,7 +90,9 @@ export class DictController {
   @RequirePermission('system:dict:add')
   @HttpCode(200)
   @Post('/data')
-  createDictData(@Body() createDictDataDto: CreateDictDataDto) {
+  createDictData(@Body() createDictDataDto: CreateDictDataDto, @Request() req) {
+    createDictDataDto['createTime'] = GetNowDate();
+    createDictDataDto['createBy'] = req.user.user.userName;
     return this.dictService.createDictData(createDictDataDto);
   }
 

--- a/server/src/module/system/notice/notice.controller.ts
+++ b/server/src/module/system/notice/notice.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Get, Post, Body, Patch, Param, Query, Put, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Query, Request, Put, Delete } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBody, ApiConsumes, ApiQuery, ApiBearerAuth } from '@nestjs/swagger';
 import { NoticeService } from './notice.service';
 import { CreateNoticeDto, UpdateNoticeDto, ListNoticeDto } from './dto/index';
 import { RequirePermission } from 'src/common/decorators/require-premission.decorator';
+import { GetNowDate } from 'src/common/utils';
 
 @ApiTags('通知公告')
 @Controller('system/notice')
@@ -17,7 +18,9 @@ export class NoticeController {
   })
   @RequirePermission('system:notice:add')
   @Post()
-  create(@Body() createConfigDto: CreateNoticeDto) {
+  create(@Body() createConfigDto: CreateNoticeDto, @Request() req) {
+    createConfigDto['createTime'] = GetNowDate();
+    createConfigDto['createBy'] = req.user.user.userName;
     return this.noticeService.create(createConfigDto);
   }
 


### PR DESCRIPTION

以下模块，新增数据时，创建时间和创建者都没有数据，目前都已经修复。
1. 字典管理
2. 字典数据
3. 参数设置
4. 通知公告