### PR TITLE
fix(server): 修复数据字典接口相关错误

### DIFF
--- a/server/src/module/system/dict/dict.controller.ts
+++ b/server/src/module/system/dict/dict.controller.ts
@@ -146,4 +146,11 @@ export class DictController {
   async export(@Res() res: Response, @Body() body: ListDictType): Promise<void> {
     return this.dictService.export(res, body);
   }
+
+  @ApiOperation({ summary: '导出字典数据为xlsx文件' })
+  @RequirePermission('system:dict:export')
+  @Post('/data/export')
+  async exportData(@Res() res: Response, @Body() body: ListDictType): Promise<void> {
+    return this.dictService.exportData(res, body);
+  }
 }

--- a/server/src/module/system/dict/dict.controller.ts
+++ b/server/src/module/system/dict/dict.controller.ts
@@ -101,8 +101,9 @@ export class DictController {
   })
   @RequirePermission('system:dict:remove')
   @Delete('/data/:id')
-  deleteDictData(@Param('id') id: string) {
-    return this.dictService.deleteDictData(+id);
+  deleteDictData(@Param('id') ids: string) {
+    const dictIds = ids.split(',').map((id) => +id);
+    return this.dictService.deleteDictData(dictIds);
   }
 
   @ApiOperation({

--- a/server/src/module/system/dict/dict.controller.ts
+++ b/server/src/module/system/dict/dict.controller.ts
@@ -140,14 +140,14 @@ export class DictController {
     return this.dictService.findOneDataType(dictType);
   }
 
-  @ApiOperation({ summary: '导出字典数据为xlsx文件' })
+  @ApiOperation({ summary: '导出字典组为xlsx文件' })
   @RequirePermission('system:dict:export')
   @Post('/type/export')
   async export(@Res() res: Response, @Body() body: ListDictType): Promise<void> {
     return this.dictService.export(res, body);
   }
 
-  @ApiOperation({ summary: '导出字典数据为xlsx文件' })
+  @ApiOperation({ summary: '导出字典内容为xlsx文件' })
   @RequirePermission('system:dict:export')
   @Post('/data/export')
   async exportData(@Res() res: Response, @Body() body: ListDictType): Promise<void> {

--- a/server/src/module/system/dict/dict.service.ts
+++ b/server/src/module/system/dict/dict.service.ts
@@ -92,7 +92,6 @@ export class DictService {
 
   async deleteDictData(dictIds: number[]) {
     await this.sysDictDataEntityRep.update({ dictCode: In(dictIds) }, { delFlag: '1' });
-    // await this.sysDictDataEntityRep.update({ dictCode: dictId }, { delFlag: '1' });
     return ResultData.ok();
   }
 

--- a/server/src/module/system/dict/dict.service.ts
+++ b/server/src/module/system/dict/dict.service.ts
@@ -115,8 +115,10 @@ export class DictService {
     if (query.status) {
       entity.andWhere('entity.status = :status', { status: query.status });
     }
+    if (query.pageSize && query.pageNum) {
+      entity.skip(query.pageSize * (query.pageNum - 1)).take(query.pageSize);
+    }
 
-    entity.skip(query.pageSize * (query.pageNum - 1)).take(query.pageSize);
     const [list, total] = await entity.getManyAndCount();
 
     return ResultData.ok({
@@ -187,6 +189,27 @@ export class DictService {
         { title: '字典名称', dataIndex: 'dictName' },
         { title: '字典类型', dataIndex: 'dictType' },
         { title: '状态', dataIndex: 'status' },
+      ],
+    };
+    ExportTable(options, res);
+  }
+
+  /**
+   * 导出字典数据为xlsx文件
+   * @param res
+   */
+  async exportData(res: Response, body: ListDictType) {
+    delete body.pageNum;
+    delete body.pageSize;
+    const list = await this.findAllData(body);
+    const options = {
+      sheetName: '字典数据',
+      data: list.data.list,
+      header: [
+        { title: '字典主键', dataIndex: 'dictCode' },
+        { title: '字典名称', dataIndex: 'dictLabel' },
+        { title: '字典类型', dataIndex: 'dictValue' },
+        { title: '备注', dataIndex: 'remark' },
       ],
     };
     ExportTable(options, res);

--- a/server/src/module/system/dict/dict.service.ts
+++ b/server/src/module/system/dict/dict.service.ts
@@ -90,8 +90,9 @@ export class DictService {
     return ResultData.ok();
   }
 
-  async deleteDictData(dictId: number) {
-    await this.sysDictDataEntityRep.update({ dictCode: dictId }, { delFlag: '1' });
+  async deleteDictData(dictIds: number[]) {
+    await this.sysDictDataEntityRep.update({ dictCode: In(dictIds) }, { delFlag: '1' });
+    // await this.sysDictDataEntityRep.update({ dictCode: dictId }, { delFlag: '1' });
     return ResultData.ok();
   }
 

--- a/server/src/module/system/dict/dto/index.ts
+++ b/server/src/module/system/dict/dto/index.ts
@@ -79,6 +79,10 @@ export class CreateDictDataDto {
   @Length(0, 100)
   listClass: string;
 
+  @IsString()
+  @Length(0, 100)
+  cssClass: string;
+
   @IsOptional()
   @IsNumber()
   dictSort?: number;

--- a/server/src/module/system/dict/dto/index.ts
+++ b/server/src/module/system/dict/dto/index.ts
@@ -79,6 +79,7 @@ export class CreateDictDataDto {
   @Length(0, 100)
   listClass: string;
 
+  @IsOptional()
   @IsString()
   @Length(0, 100)
   cssClass: string;


### PR DESCRIPTION

修复数据字典接口相关的错误，并添加相关注释

- 批量删除数据字典内容（原先只能单个删除）
- 新增导出数据字典内容（原先只能导出数据字典组，没有数据字典内容的导出接口）
- 修复数据字典cssClass字段无法新增和修改的问题