### PR TITLE
replace "@liaoliaots/nestjs-redis": "^9.0.5" to "@songkeys/nestjs-red…

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "start": "nest start",
+    "start": "npm run start:dev",
     "start:dev": "cross-env NODE_ENV=development nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "cross-env NODE_ENV=production node dist/main",

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@liaoliaots/nestjs-redis": "^9.0.5",
+    "@songkeys/nestjs-redis": "^10.0.0",
     "@nestjs/axios": "^3.0.2",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.1.1",

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,7 +1,7 @@
 import { Module, Global } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
-import { RedisClientOptions } from '@liaoliaots/nestjs-redis';
+import { RedisClientOptions } from '@songkeys/nestjs-redis';
 import configuration from './config/index';
 import { HttpModule } from '@nestjs/axios';
 import { APP_GUARD } from '@nestjs/core';

--- a/server/src/module/redis/redis.module.ts
+++ b/server/src/module/redis/redis.module.ts
@@ -1,4 +1,4 @@
-import { RedisModule as liaoliaoRedisModule, RedisModuleAsyncOptions } from '@liaoliaots/nestjs-redis';
+import { RedisModule as liaoliaoRedisModule, RedisModuleAsyncOptions } from '@songkeys/nestjs-redis';
 import { DynamicModule, Global, Module } from '@nestjs/common';
 
 import { RedisService } from './redis.service';

--- a/server/src/module/redis/redis.service.ts
+++ b/server/src/module/redis/redis.service.ts
@@ -1,4 +1,4 @@
-import { InjectRedis } from '@liaoliaots/nestjs-redis';
+import { InjectRedis } from '@songkeys/nestjs-redis';
 import { Injectable } from '@nestjs/common';
 import Redis from 'ioredis';
 


### PR DESCRIPTION
npm install 会报如下错误

npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: nest-v10@0.0.1
npm error Found: @nestjs/common@10.4.7
npm error node_modules/@nestjs/common
npm error   @nestjs/common@"^10.0.0" from the root project
npm error
npm error Could not resolve dependency:
npm error peer @nestjs/common@"^9.0.0" from @liaoliaots/nestjs-redis@9.0.5
npm error node_modules/@liaoliaots/nestjs-redis
npm error   @liaoliaots/nestjs-redis@"^9.0.5" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error C:\Users\Administrator\AppData\Local\npm-cache\_logs\2024-11-12T08_30_07_431Z-eresolve-report.txt
npm error A complete log of this run can be found in: C:\Users\Administrator\AppData\Local\npm-cache\_logs\2024-11-12T08_30_07_431Z-debug-0.log

这是因为 @liaoliaots/nestjs-redis@9.0.5 作者已经不再维护，所以替换为"@songkeys/nestjs-redis": "^10.0.0" 替代