### PR TITLE
fix(server): 修复白名单的路径对比逻辑，防止携带参数影响访问

### DIFF
--- a/server/src/common/guards/auth.guard.ts
+++ b/server/src/common/guards/auth.guard.ts
@@ -72,7 +72,7 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
       // 请求方法类型相同
       if (!route.method || req.method.toUpperCase() === route.method.toUpperCase()) {
         // 对比 url
-        return !!pathToRegexp(route.path).exec(req.url);
+        return !!pathToRegexp(route.path).exec(req.route.path);
       }
       return false;
     });


### PR DESCRIPTION
- 将 req.url 替换为 req.route.path 进行路径匹配
- 这个修改确保了在使用通配符路由时能够正确执行鉴权检查，防止携带参数的接口出问题